### PR TITLE
Update tests for successful help exit

### DIFF
--- a/llvmup
+++ b/llvmup
@@ -226,6 +226,13 @@ log_error() {
 }
 
 usage() {
+    local previous_exit=$?
+    local exit_code="${1:-$previous_exit}"
+
+    if [ $# -eq 0 ] && [ "$exit_code" -eq 0 ]; then
+        exit_code=1
+    fi
+
     cat <<EOF
 Usage: llvmup [install] [OPTIONS] [VERSION]
 
@@ -262,7 +269,7 @@ Examples:
   llvmup config init                              # Initialize project config
   llvmup config activate                          # Activate from config
 EOF
-    exit 1
+    exit "$exit_code"
 }
 
 # Parse command line arguments
@@ -288,7 +295,7 @@ fi
 # Handle non-install commands early
 case "$COMMAND" in
     help)
-        usage
+        usage 0
         ;;
     default)
         if [ $# -eq 0 ]; then
@@ -373,7 +380,7 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         -h|--help)
-            usage
+            usage 0
             ;;
         --)
             shift

--- a/tests/integration/test_enhanced_workflow.bats
+++ b/tests/integration/test_enhanced_workflow.bats
@@ -224,8 +224,8 @@ EOF
 
 @test "Help system shows all new options" {
     run bash "$ORIGINAL_DIR/llvmup" --help
-    # Help exits with code 1, but shows the help correctly
-    [ "$status" -eq 1 ]
+    # Help exits successfully and shows the help correctly
+    assert_success
 
     # Check for all new options
     assert_output --partial "--cmake-flags"

--- a/tests/unit/test_llvmup_config_activate.bats
+++ b/tests/unit/test_llvmup_config_activate.bats
@@ -76,7 +76,7 @@ EOF
 @test "llvmup help - shows config command in usage" {
     run "$LLVMUP_SCRIPT" help
 
-    [ "$status" -eq 1 ]
+    [ "$status" -eq 0 ]
     [[ "$output" == *"config           Manage project configuration"* ]]
     [[ "$output" == *"llvmup config init"* ]]
     [[ "$output" == *"llvmup config activate"* ]]

--- a/tests/unit/test_llvmup_enhanced.bats
+++ b/tests/unit/test_llvmup_enhanced.bats
@@ -26,8 +26,8 @@ teardown() {
 
 @test "llvmup shows enhanced help with new options" {
     run bash "$ORIGINAL_DIR/llvmup" --help
-    # The help command returns 1 (exit after showing help), but shows the help correctly
-    [ "$status" -eq 1 ]
+    # Help exits successfully and shows the enhanced options
+    assert_success
     assert_output --partial "--cmake-flags"
     assert_output --partial "--name"
     assert_output --partial "--default"
@@ -82,32 +82,32 @@ teardown() {
 @test "llvmup install accepts cmake-flags option" {
     # Test that llvmup accepts the cmake-flags option (parsing test)
     run bash "$ORIGINAL_DIR/llvmup" install --help
-    # Help exits with code 1, but shows the help
-    [ "$status" -eq 1 ]
+    # Help exits successfully but still shows the usage text
+    assert_success
     assert_output --partial "--cmake-flags"
 }
 
 @test "llvmup install accepts name option" {
     # Test that llvmup accepts the name option (parsing test)
     run bash "$ORIGINAL_DIR/llvmup" install --help
-    # Help exits with code 1, but shows the help
-    [ "$status" -eq 1 ]
+    # Help exits successfully but still shows the usage text
+    assert_success
     assert_output --partial "--name"
 }
 
 @test "llvmup install accepts default option" {
     # Test that llvmup accepts the default option (parsing test)
     run bash "$ORIGINAL_DIR/llvmup" install --help
-    # Help exits with code 1, but shows the help
-    [ "$status" -eq 1 ]
+    # Help exits successfully but still shows the usage text
+    assert_success
     assert_output --partial "--default"
 }
 
 @test "llvmup install accepts profile option" {
     # Test that llvmup accepts the profile option (parsing test)
     run bash "$ORIGINAL_DIR/llvmup" install --help
-    # Help exits with code 1, but shows the help
-    [ "$status" -eq 1 ]
+    # Help exits successfully but still shows the usage text
+    assert_success
     assert_output --partial "--profile"
 }
 
@@ -120,16 +120,16 @@ teardown() {
 @test "llvmup install accepts component option" {
     # Test that llvmup accepts the component option (parsing test)
     run bash "$ORIGINAL_DIR/llvmup" install --help
-    # Help exits with code 1, but shows the help
-    [ "$status" -eq 1 ]
+    # Help exits successfully but still shows the usage text
+    assert_success
     assert_output --partial "--component"
 }
 
 @test "llvmup install passes multiple cmake-flags correctly" {
     # Test that llvmup accepts multiple cmake-flags (parsing test)
     run bash "$ORIGINAL_DIR/llvmup" install --help
-    # Help exits with code 1, but shows the help
-    [ "$status" -eq 1 ]
+    # Help exits successfully but still shows the usage text
+    assert_success
     assert_output --partial "--cmake-flags"
     assert_output --partial "can be repeated"
 }
@@ -137,8 +137,8 @@ teardown() {
 @test "llvmup install combines all options correctly" {
     # Test that llvmup help shows all the new options
     run bash "$ORIGINAL_DIR/llvmup" install --help
-    # Help exits with code 1, but shows the help
-    [ "$status" -eq 1 ]
+    # Help exits successfully but still shows the usage text
+    assert_success
     assert_output --partial "--name"
     assert_output --partial "--default"
     assert_output --partial "--profile"

--- a/tests/unit/test_llvmup_libc_wno_error.bats
+++ b/tests/unit/test_llvmup_libc_wno_error.bats
@@ -18,8 +18,8 @@ load "../fixtures/test_helpers.bash"
 @test "llvmup help includes --disable-libc-wno-error option" {
     run ./llvmup --help
 
-    # Help exits with code 1, but that's expected behavior
-    [ "$status" -eq 1 ]
+    # Help exits successfully when requested explicitly
+    assert_success
     assert_output --partial "--disable-libc-wno-error"
     assert_output --partial "Disable LIBC_WNO_ERROR=ON flag"
 }


### PR DESCRIPTION
## Summary
- update unit tests to expect successful exit codes for `llvmup` help flows
- adjust integration coverage to assert help requests succeed while still validating messaging
- refresh comments to explain that help now exits cleanly

## Testing
- tests/run_tests.sh > /tmp/tests.log

------
https://chatgpt.com/codex/tasks/task_e_68cf410ad2a883268bde846ee0bf3eee