### PR TITLE
Remove duplicate log function overrides

### DIFF
--- a/llvmup
+++ b/llvmup
@@ -209,22 +209,6 @@ case "${1:-}" in
 esac
 
 # Parse command line options
-log_verbose() {
-    if [ "$VERBOSE" -eq 1 ] && [ "$QUIET" -eq 0 ]; then
-        echo "[VERBOSE] $*" >&2
-    fi
-}
-
-log_info() {
-    if [ "$QUIET" -eq 0 ]; then
-        echo "$*"
-    fi
-}
-
-log_error() {
-    echo "Error: $*" >&2
-}
-
 usage() {
     local previous_exit=$?
     local exit_code="${1:-$previous_exit}"


### PR DESCRIPTION
## Summary
- remove the duplicate log function overrides near option parsing so the script reuses the emoji/stderr logging helpers

## Testing
- ./llvmup --help
- PATH=/tmp/fakebin:$PATH ./llvmup install --quiet
- ./llvmup default show

------
https://chatgpt.com/codex/tasks/task_e_68cf59e75784832684b802ef04719100